### PR TITLE
Enable releases to mavenCentral via GitHub Actions

### DIFF
--- a/.github/workflows/buildAndPush.yml
+++ b/.github/workflows/buildAndPush.yml
@@ -70,6 +70,13 @@ jobs:
           distribution: 'temurin'
           java-version: '21'
 
+      - name: "⬇️ Install GPG"
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        run: |
+          brew install gpg
+          echo "$SIGNING_KEY" | gpg --dearmor > ${HOME}/secring.gpg
+
       - name: "⚙️ Setup Gradle"
         uses: gradle/actions/setup-gradle@v3
         with:
@@ -81,3 +88,7 @@ jobs:
           VERSION: ${{ needs.infer-release.outputs.version }}
           GITHUB_ACTOR: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
+          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -4,30 +4,25 @@ This is a fork of [alexzhirkevich/compose-cupertino](https://github.com/alexzhir
 
 Additionally this repo has automated builds to enable faster releases, to take advantage of new compose multiplatform features as they become available.
 
+## New features (compared to the OG `compose-cupertino`)
+
+- Updated SwipeBox
+- Fixed Cupertino Date Picker implementations to interact with scrolling correctly
+
 # Usage
 
-For now this package is only available via github packages.
+This package is updated to both MavenCentral and GitHub Packages.
 
-Add the following to your settings.gradle.kts, making sure that you have set or provided mavenUser and mavenPassword to your github username and a Personal Access Token.
-```
-maven {
-    url = uri("https://maven.pkg.github.com/schott12521/compose-cupertino")
-    credentials {
-        username = mavenUser
-        password = mavenPassword
-    }
-}
-```
-Then you can depend on the [latest version](https://github.com/schott12521/compose-cupertino/releases) of the library (including my SwipeBox changes), in libs.versions.toml:
+Depend on the [latest version](https://github.com/schott12521/compose-cupertino/releases) by declaring this in libs.versions.toml:
 
 ```
 cupertino = "$latestVersion"
 
-cupertino = { group = "com.slapps.cupertino", name = "cupertino", version.ref = "cupertino" }
-cupertino-adaptive = { group = "com.slapps.cupertino", name = "cupertino-adaptive", version.ref = "cupertino" }
-cupertino-decompose = { group = "com.slapps.cupertino", name = "cupertino-decompose", version.ref = "cupertino" }
-cupertino-native = { group = "com.slapps.cupertino", name = "cupertino-native", version.ref = "cupertino" }
-cupertino-icons-extended = { module = "com.slapps.cupertino:cupertino-icons-extended", version.ref = "cupertino" }
+cupertino = { group = "io.github.schott12521", name = "cupertino", version.ref = "cupertino" }
+cupertino-adaptive = { group = "io.github.schott12521", name = "cupertino-adaptive", version.ref = "cupertino" }
+cupertino-decompose = { group = "io.github.schott12521", name = "cupertino-decompose", version.ref = "cupertino" }
+cupertino-native = { group = "io.github.schott12521", name = "cupertino-native", version.ref = "cupertino" }
+cupertino-icons-extended = { group = "io.github.schott12521", name = "cupertino-icons-extended", version.ref = "cupertino" }
 ```
 
 Note this repo is not officially supported in any capacity; changes will be applied upstream when applicable ([example1](https://github.com/alexzhirkevich/compose-cupertino/pull/74), [example2](https://github.com/alexzhirkevich/compose-cupertino/pull/77))

--- a/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/publishing-convention.gradle.kts
@@ -3,32 +3,41 @@ import java.util.Properties
 
 plugins {
     `maven-publish`
+    signing
 }
 
-publishing {
-    repositories {
-        maven {
-            name = "GitHubPackages"
-            url = uri("https://maven.pkg.github.com/schott12521/compose-cupertino")
-            credentials {
-                username = System.getenv("GITHUB_ACTOR")
-                password = System.getenv("GITHUB_TOKEN")
-            }
-        }
-    }
+// Load publish properties (for your project description, etc.)
+val publishProperties = Properties().apply {
+    load(file("publish.properties").inputStream())
 }
 
-val publishProperties =
-    Properties().apply {
-        load(file("publish.properties").inputStream())
-    }
+// Check if we’re on GitHub Actions
+val isGithubActions = System.getenv("GITHUB_ACTIONS") == "true"
 
+val computedVersion = if (isGithubActions) {
+    val ref = System.getenv("GITHUB_REF") ?: ""
+    if (ref.startsWith("refs/tags/")) {
+        // e.g. "refs/tags/1.2.3" -> "1.2.3"
+        ref.removePrefix("refs/tags/")
+    } else {
+        // On a push to a non-tag branch, or something else
+        "0.0.0-LOCAL"
+    }
+} else {
+    // Local build fallback
+    "0.0.0-LOCAL"
+}
+version = computedVersion
+
+// Create Javadoc JAR (even if it's empty)
 val javadocJar by tasks.registering(Jar::class) {
     archiveClassifier.set("javadoc")
 }
 
 publishing.publications.withType<MavenPublication> {
     artifact(javadocJar.get())
+
+    // If your code can also run locally, set up the pom:
     pom {
         name.set(project.name)
         description.set(publishProperties.getProperty("description"))
@@ -56,6 +65,43 @@ publishing.publications.withType<MavenPublication> {
             connection.set("scm:git:https://github.com/schott12521/ExampleLibrary.git")
             developerConnection.set("scm:git:ssh://github.com/schott12521/ExampleLibrary.git")
             url.set("https://github.com/schott12521/ExampleLibrary")
+        }
+    }
+}
+
+// 2) Only configure remote repositories & signing if we're in GitHub Actions
+if (isGithubActions) {
+
+    // Repositories
+    publishing {
+        repositories {
+            maven {
+                name = "GitHubPackages"
+                url = uri("https://maven.pkg.github.com/schott12521/compose-cupertino")
+                credentials {
+                    username = System.getenv("GITHUB_ACTOR")
+                    password = System.getenv("GITHUB_TOKEN")
+                }
+            }
+            maven {
+                name = "MavenCentral"
+                url = uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+                credentials {
+                    username = System.getenv("OSSRH_USERNAME")
+                    password = System.getenv("OSSRH_PASSWORD")
+                }
+            }
+        }
+    }
+
+    // Signing
+    signing {
+        val signingKey = System.getenv("SIGNING_KEY")
+        val signingPassword = System.getenv("SIGNING_PASSWORD")
+
+        if (!signingKey.isNullOrBlank() && !signingPassword.isNullOrBlank()) {
+            useInMemoryPgpKeys(signingKey, signingPassword)
+            sign(publishing.publications)
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group=com.slapps.cupertino
+group=io.github.schott12521
 
 #Gradle
 org.gradle.jvmargs=-Xmx4096M -Dfile.encoding=UTF-8 -Dkotlin.daemon.jvm.options\="-Xmx4096M"


### PR DESCRIPTION
This PR / commit enables releases to maven central using the already established build and publish action, but by adding the additional config required for maven central.

To enable publishing to mavenCentral, I need to change the package import from `com.slapps.cupertino` to `io.github.schott12521.cupertino`

There's a high probability this doesn't work initially, but we'll give it a shot and see what happens.

I was able to test this locally by publishing to maven local and then consuming the package in another local repo.

https://github.com/schott12521/compose-cupertino/issues/21