### PR TITLE
WIP-fix: updating project to work with cmp 1.8.0

### DIFF
--- a/buildSrc/src/main/kotlin/multiplatform-module-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/multiplatform-module-convention.gradle.kts
@@ -41,7 +41,7 @@ kotlin {
         compilations.all {
             compileTaskProvider.configure {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_1_8)
+                    jvmTarget.set(JvmTarget.JVM_11)
                 }
             }
         }
@@ -58,7 +58,7 @@ kotlin {
         compilations.all {
             compileTaskProvider.configure {
                 compilerOptions {
-                    jvmTarget.set(JvmTarget.JVM_1_8)
+                    jvmTarget.set(JvmTarget.JVM_11)
                 }
             }
         }
@@ -119,7 +119,7 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 }

--- a/example/composeApp/build.gradle.kts
+++ b/example/composeApp/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_1_8)
+            jvmTarget.set(JvmTarget.JVM_11)
         }
     }
 
@@ -133,8 +133,8 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ decompose = "3.2.2"
 essenty = "2.2.1"
 serialization="1.7.3"
 atomicfu="0.23.2"
-jetbrainsCompose="1.7.3"
+jetbrainsCompose="1.8.0-alpha03"
 vanniktech-mavenPublish="0.30.0"
 
 [libraries]


### PR DESCRIPTION
Storing this until CMP 1.8.0 gets released, as I don't want to manage a separate alpha version but it appears these are the necessary changes.

This might warrant a large version bump as consumers on JVM 1.8 may begin to have issues using the library after this change.